### PR TITLE
Use tag for restruct dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/anchore/go-rpmdb
 go 1.14
 
 require (
-	github.com/go-restruct/restruct v0.0.0-20191227155143-5734170a48a1
+	github.com/go-restruct/restruct v1.2.0-alpha
 	github.com/go-test/deep v1.0.7
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-restruct/restruct v0.0.0-20191227155143-5734170a48a1 h1:LoN2wx/aN8JPGebG+2DaUyk4M+xRcqJXfuIbs8AWHdE=
-github.com/go-restruct/restruct v0.0.0-20191227155143-5734170a48a1/go.mod h1:KqrpKpn4M8OLznErihXTGLlsXFGeLxHUrLRRI/1YjGk=
+github.com/go-restruct/restruct v1.2.0-alpha h1:2Lp474S/9660+SJjpVxoKuWX09JsXHSrdV7Nv3/gkvc=
+github.com/go-restruct/restruct v1.2.0-alpha/go.mod h1:KqrpKpn4M8OLznErihXTGLlsXFGeLxHUrLRRI/1YjGk=
 github.com/go-test/deep v1.0.7 h1:/VSMRlnY/JSyqxQUzQLKVMAskpY/NZKFA5j2P+0pP2M=
 github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=


### PR DESCRIPTION
Restruct tagged the referenced commit as [v1.2.0-alpha](https://github.com/go-restruct/restruct/releases/tag/v1.2.0-alpha) which trips up some GOPROXY servers (see https://github.com/golang/go/issues/32879#issuecomment-507861612)

This prevents building grype if using an affected GOPROXY. 

Signed-off-by: Conor Nosal <cnosal@vmware.com>