### PR TITLE
Switch to anchore imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"log"
 
-	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
+	rpmdb "github.com/anchore/go-rpmdb/pkg"
 )
 
 func main() {

--- a/cmd/rpmdb/main.go
+++ b/cmd/rpmdb/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
+	rpmdb "github.com/anchore/go-rpmdb/pkg"
 	multierror "github.com/hashicorp/go-multierror"
-	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
 
 	_ "github.com/glebarez/go-sqlite"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/knqyf263/go-rpmdb
+module github.com/anchore/go-rpmdb
 
 go 1.18
 

--- a/pkg/bdb/bdb.go
+++ b/pkg/bdb/bdb.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"os"
 
-	dbi "github.com/knqyf263/go-rpmdb/pkg/db"
+	dbi "github.com/anchore/go-rpmdb/pkg/db"
 	"golang.org/x/xerrors"
 )
 

--- a/pkg/ndb/ndb.go
+++ b/pkg/ndb/ndb.go
@@ -28,7 +28,7 @@ import (
 	"os"
 	"unsafe"
 
-	dbi "github.com/knqyf263/go-rpmdb/pkg/db"
+	dbi "github.com/anchore/go-rpmdb/pkg/db"
 	"golang.org/x/xerrors"
 )
 

--- a/pkg/rpmdb.go
+++ b/pkg/rpmdb.go
@@ -1,10 +1,10 @@
 package rpmdb
 
 import (
-	"github.com/knqyf263/go-rpmdb/pkg/bdb"
-	dbi "github.com/knqyf263/go-rpmdb/pkg/db"
-	"github.com/knqyf263/go-rpmdb/pkg/ndb"
-	"github.com/knqyf263/go-rpmdb/pkg/sqlite3"
+	"github.com/anchore/go-rpmdb/pkg/bdb"
+	dbi "github.com/anchore/go-rpmdb/pkg/db"
+	"github.com/anchore/go-rpmdb/pkg/ndb"
+	"github.com/anchore/go-rpmdb/pkg/sqlite3"
 	"golang.org/x/xerrors"
 )
 

--- a/pkg/sqlite3/sqlite3.go
+++ b/pkg/sqlite3/sqlite3.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"os"
 
-	dbi "github.com/knqyf263/go-rpmdb/pkg/db"
+	dbi "github.com/anchore/go-rpmdb/pkg/db"
 	"golang.org/x/xerrors"
 )
 


### PR DESCRIPTION
Syft will be using this fork of go-rpmdb while changes are being made upstream. In the meantime to use this fork without a replace directive we will adjust the imports to be hardcoded to this fork.