### PR TITLE
Tighten workflow permissions and update dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   - package-ecosystem: gomod
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
@@ -13,19 +13,11 @@ updates:
       - "dependencies"
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
-      interval: "daily"
-    cooldown:
-      default-days: 7
-    open-pull-requests-limit: 10
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions/boostrap"
-    schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,6 @@
 name: "Release"
 
-permissions:
-  contents: read
+permissions: {}
 
 # there should never be two releases in progress at the same time
 concurrency:

--- a/.github/workflows/validate-github-actions.yaml
+++ b/.github/workflows/validate-github-actions.yaml
@@ -10,8 +10,7 @@ on:
       - '.github/workflows/**'
       - '.github/actions/**'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   zizmor:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -6,8 +6,7 @@ on:
       - master
   pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
 
@@ -15,6 +14,8 @@ jobs:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Static analysis"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       # setup checkout, go, go-make, binny, and cache go modules
       - uses: anchore/go-make/.github/actions/setup@383ef7852b8ae43a30f424896b52479186d2ea4d # v0.1.0
@@ -26,6 +27,8 @@ jobs:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Unit tests"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       # setup checkout, go, go-make, binny, and cache go modules
       - uses: anchore/go-make/.github/actions/setup@383ef7852b8ae43a30f424896b52479186d2ea4d # v0.1.0


### PR DESCRIPTION
Moves workflow-level permissions to {} for all three workflow files, pushing contents: read down to the job level where each job actually needs it. Also consolidates the two github-actions dependabot entries into one with a directories: list, and changes the gomod and github-actions schedule intervals from daily to weekly.

Changes:
- set top-level permissions: {} in release.yaml, validate-github-actions.yaml, and validations.yaml
- add job-level permissions: { contents: read } to Static-Analysis and Unit-Test jobs in validations.yaml
- consolidate two github-actions dependabot entries into one using directories: ["/" , "/.github/actions/*"]
- change gomod and github-actions dependabot schedule interval from daily to weekly

Notes:
- release.yaml already had job-level permissions on the release job, no change needed there
- validate-github-actions.yaml already had job-level permissions on the zizmor job, no change needed there